### PR TITLE
fix: profile check flow and device_id registration

### DIFF
--- a/src/middleware/checkJwt.ts
+++ b/src/middleware/checkJwt.ts
@@ -1,6 +1,7 @@
-import { expressjwt } from "express-jwt";
+import { expressjwt, UnauthorizedError } from "express-jwt";
 import jwksRsa from "jwks-rsa";
 import dotenv from "dotenv";
+import { Request,Response,NextFunction } from "express";
 
 dotenv.config();
 
@@ -22,3 +23,29 @@ export const checkJwt = expressjwt({
   issuer: `https://${process.env.AUTH0_DOMAIN}/`,
   algorithms: ["RS256"],
 });
+export const optionalCheckJwt = expressjwt({
+  secret: jwksRsa.expressJwtSecret({
+    cache: true,
+    rateLimit: true,
+    jwksRequestsPerMinute: 5,
+    jwksUri: `https://${process.env.AUTH0_DOMAIN}/.well-known/jwks.json`,
+  }) as any,
+  audience:process.env.AUTH0_AUDIENCE,
+  issuer: `https://${process.env.AUTH0_DOMAIN}/`,
+  algorithms: ["RS256"],
+  credentialsRequired: false,
+});
+export const handleExpiredJwt = (
+  err: Error,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (err instanceof UnauthorizedError){
+    next();
+  }else{
+    next(err);
+  }
+};
+ 
+

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,3 +1,3 @@
-export { checkJwt } from "./checkJwt";
+export { checkJwt,optionalCheckJwt,handleExpiredJwt } from "./checkJwt";
 export { upload } from "./upload";
 export { uploadToCloudinary } from "./uploadPhoto";

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -28,7 +28,7 @@ export class ProfileController {
     }
 
     try {
-      const { name, dateOfBirth, location, reasons, gender } = req.body;
+      const { name, dateOfBirth, location, reasons, gender,device_id } = req.body;
 
       if (!name) {
         return res.status(400).json({ error: "Name is required" });
@@ -72,7 +72,8 @@ export class ProfileController {
         reasons,
         gender,
         preferences,
-        files
+        files,
+        device_id
       );
 
       return res.status(201).json(newProfile);
@@ -174,29 +175,40 @@ export class ProfileController {
     }
   };
 
-  checkProfileExistsById = async (
-    req: Request,
-    res: Response
-  ): Promise<Response> => {
+  checkProfileExistsById = async (req: Request, res: Response): Promise<Response> => {
     console.log("controller checkProfileExistsById");
 
-    const userId = extractUserId(req);
-    if (!userId) {
-      return res
-        .status(401)
-        .json({ message: "Unauthorized: No token provided" });
-    }
+    const isAuthenticated = !!(req as any).auth;
 
-    try {
-      const exists = await this.profileService.checkProfileExists(userId);
-      return res.json(exists);
-    } catch (error) {
-      return handleServiceError(
-        error,
-        "Error checkProfileExistsById",
-        res,
-        400
-      );
+    if (isAuthenticated) {
+      const userId = extractUserId(req);
+      if (!userId) {
+        return res.status(401).json({ message: "Unauthorized: Invalid token" });
+      }
+      try {
+        const profile = await this.profileService.getProfileById(userId).catch(() => null);
+        if (!profile || !profile.isProfileComplete) {
+          return res.status(204).send();
+        }
+        return res.status(200).json({ message: "Profile complete" });
+      } catch (error) {
+        return handleServiceError(error, "Error checkProfileExistsById", res, 400);
+      }
+    } else {
+      const deviceId = req.query.device_id as string;
+      if (!deviceId) {
+        return res.status(404).json({ message: "No credentials provided" });
+      }
+      try {
+        const profile = await this.profileService.findProfileByDeviceId(deviceId);
+        if (profile) {
+          return res.status(401).json({ message: "Unauthorized: Please log in" });
+        } else {
+          return res.status(404).json({ message: "No profile found for this device" });
+        }
+      } catch (error) {
+        return handleServiceError(error, "Error checkProfileExistsById", res, 400);
+      }
     }
   };
 

--- a/src/modules/profile/profile.model.ts
+++ b/src/modules/profile/profile.model.ts
@@ -22,6 +22,8 @@ export interface Preferences {
 
 export interface ProfileDocument extends Document {
   _id: string;
+  device_id?: string;
+  isProfileComplete: boolean;
   name: string;
   dateOfBirth: Date;
   location: Location;
@@ -39,6 +41,8 @@ export interface ProfileDocument extends Document {
 const profileSchema = new Schema<ProfileDocument>(
   {
     _id: { type: String, required: true },
+    device_id:{type:String, index:true },
+    isProfileComplete: { type: Boolean, default: false},
     name: { type: String, required: true },
     dateOfBirth: { type: Date, required: true },
     zodiacSign: { type: String },

--- a/src/modules/profile/profile.route.ts
+++ b/src/modules/profile/profile.route.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { upload, checkJwt } from "../../middleware";
+import { upload, checkJwt,optionalCheckJwt, handleExpiredJwt} from "../../middleware";
 import { ProfileController } from "./profile.controller";
 import { ProfileService } from "./profile.service";
 import { LikeService } from "../like/like.service";
@@ -113,7 +113,7 @@ router.get("/", checkJwt, profileController.getCurrentProfile);
  *       400:
  *         description: Bad request
  */
-router.get("/check", checkJwt, profileController.checkProfileExistsById);
+router.get("/check", optionalCheckJwt, handleExpiredJwt, profileController.checkProfileExistsById);
 
 /**
  * @swagger

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -20,6 +20,14 @@ export class ProfileService {
     this.likeService = likeService;
     this.matchService = matchService;
   }
+  findProfileByDeviceId = async (deviceId: string): Promise<ProfileDocument | null> => {
+    try{
+      return await Profile.findOne({device_id: deviceId}).exec();
+    }catch(error: unknown) {
+      if(error instanceof Error) throw new Error (error.message);
+      throw new Error("Error finding profile by device_id");
+    }
+  };
 
   registerProfile = async (
     userId: string,
@@ -29,11 +37,12 @@ export class ProfileService {
     reasons: string[],
     gender: string,
     preferences: Preferences,
-    files: Express.Multer.File[]
+    files: Express.Multer.File[],
+    deviceId? : string 
   ) => {
     try {
-      const profileExists = await this.checkProfileExists(userId);
-      if (profileExists) {
+      const existingProfile = await Profile.findById(userId).exec();
+      if (existingProfile && existingProfile.isProfileComplete) {
         throw new Error("Profile already exists");
       }
 
@@ -70,9 +79,32 @@ export class ProfileService {
 
       const parsedReasons: string[] =
         typeof reasons === "string" ? JSON.parse(reasons) : reasons;
+        
+        if(existingProfile){
+          return await Profile.findByIdAndUpdate(
+            userId,
+            {
+              name,
+              dateOfBirth,
+              zodiacSign,
+              location: parsedLocation,
+              gender,
+              reasons: parsedReasons,
+              preferences,
+              friendsAgeMin,
+              friendsAgeMax,
+              photos: uploadedFiles,
+              isProfileComplete: true,
+              ...(deviceId && {device_id: deviceId}),
+            },
+            {new:true}
+          ).exec();
+        }
 
       const newProfile = new Profile({
         _id: userId,
+        device_id: deviceId,
+        isProfileComplete: true,
         name,
         dateOfBirth,
         zodiacSign,


### PR DESCRIPTION
## Task               
  https://app.clickup.com/t/869cp40x5                                                                   
                                                                                                          
  ## What was done                                                                                        
  - **GET /api/profile/check** — reworked response logic to distinguish 4 states:                         
    - `200` — authenticated + profile complete                                                          
    - `204` — authenticated, profile not filled yet                                                     
    - `401` — not authenticated, but profile with this device_id exists                                 
    - `404` — not authenticated, no profile found for this device_id                                    
  - **POST /api/profile** — allowed profile creation when user has valid token but profile is incomplete  
  (fixes registration loop bug)                                                                           
  - **device_id** — now correctly extracted from request body and saved to profile on registration        
  - **handleExpiredJwt** — expired tokens on /check are now treated as unauthenticated instead of raw 401 
  from middleware