### PR TITLE
fix: exclude friends from nearest profiles and fix age 
  calculation

### DIFF
--- a/src/modules/match/match.service.ts
+++ b/src/modules/match/match.service.ts
@@ -1,3 +1,4 @@
+import moment from "moment";
 import { ChatService } from "../chat/chat.service";
 import { LikeService } from "../like/like.service";
 import { ProfileService } from "../profile/profile.service";
@@ -99,8 +100,7 @@ export class MatchService {
         .map(({ friend }) => ({
           id: friend.id,
           name: friend.name,
-          // amazonq-ignore-next-line
-          age: new Date().getFullYear() - friend.dateOfBirth.getFullYear(),
+          age: moment().diff(moment(friend.dateOfBirth), "years"),
           photo: friend.photos?.[0] || null,
         }));
 

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -410,6 +410,8 @@ export class ProfileService {
 
       const allProfiles = await this.getAllProfiles(userId);
 
+      const userLikes = this.likeService ? await this.likeService.getLikes(userId) : null;
+
       const nearestProfiles = await Promise.all(
         allProfiles
           .filter((profile) => profile.location?.lat && profile.location?.lng)
@@ -422,6 +424,10 @@ export class ProfileService {
             );
 
             if (distance <= currentProfile.friendsDistance!) {
+              const hasLiked = userLikes?.likes?.some((like) => like.liked_id === profile.id);
+              const hasMatch = await this.matchService?.hasMatch(userId, profile.id);
+              if (hasLiked || hasMatch) return null;
+
               const profileLikes = this.likeService ? await this.likeService.getLikes(profile.id) : { likes: [] };
               return {
                 id: profile.id,


### PR DESCRIPTION
https://app.clickup.com/t/869bwvgyf

 **Summary**                                                                  
                                                                                
  Friends (matched users) no longer appear in the swipes/nearest profiles  feed                                                                          
   Fixed age calculation - was off by 1 year before the user's birthday      
                                                                                                                                                          
   **Root cause**                                                               
    `getNearestProfiles()` was missing `hasLiked`/`hasMatch` checks that  already  existed in `searchFriends()`.
    Age was calculated with simple year  subtraction instead of `moment().diff()`.                                               
                                                                                                                                                           
    **Changes**                                                                  
    `profile.service.ts` - added match and like filtering in  `getNearestProfiles()`   `match.service.ts` - standardized age calculation to use  `moment().diff()
