### PR TITLE
fix: return full preference arrays in profile view and fix age calculation

### DIFF
--- a/src/modules/match/match.service.ts
+++ b/src/modules/match/match.service.ts
@@ -1,3 +1,4 @@
+import moment from "moment";
 import { ChatService } from "../chat/chat.service";
 import { LikeService } from "../like/like.service";
 import { ProfileService } from "../profile/profile.service";
@@ -96,13 +97,30 @@ export class MatchService {
 
       const modifiedFriends = friendsWithChats
         .filter(({ hasChat }) => !hasChat)
-        .map(({ friend }) => ({
-          id: friend.id,
-          name: friend.name,
-          // amazonq-ignore-next-line
-          age: new Date().getFullYear() - friend.dateOfBirth.getFullYear(),
-          photo: friend.photos?.[0] || null,
-        }));
+        .map(({ friend }) => {
+          const friendObject = friend.toObject();
+          return {
+            id: friendObject._id,
+            name: friendObject.name,
+            age: moment().diff(moment(friendObject.dateOfBirth), "years"),
+            photos: friendObject.photos?.map((photo: string) => ({ src: photo })) || [],
+            zodiacSign: friendObject.zodiacSign,
+            city: friendObject.location?.city || "",
+            reasons: friendObject.reasons,
+            preferences: {
+              questionary: {
+                smoking: friendObject.preferences?.smoking || [],
+                education: friendObject.preferences?.educationalLevel || [],
+                children: friendObject.preferences?.children || [],
+                drinking: friendObject.preferences?.drinking || [],
+                pets: friendObject.preferences?.pets || [],
+                language: friendObject.preferences?.selectedLanguages || [],
+              },
+              interests: friendObject.preferences?.interests || [],
+              aboutMe: friendObject.preferences?.aboutMe || "",
+            },
+          };
+        });
 
       return modifiedFriends;
     } catch (error: unknown) {

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -1,3 +1,4 @@
+import moment from "moment";
 import { Request, Response } from "express";
 import {
   extractUserId,
@@ -139,9 +140,7 @@ export class ProfileController {
       const performedUser = {
         _id: targetUserObject._id,
         name: targetUserObject.name,
-        age: Math.round(
-          new Date().getFullYear() - targetUserObject.dateOfBirth.getFullYear()
-        ),
+        age: moment().diff(moment(targetUserObject.dateOfBirth), "years"),
         zodiacSign: targetUserObject.zodiacSign,
         city: targetUserObject.location.city,
         distance: haversineDistance(
@@ -157,15 +156,15 @@ export class ProfileController {
         reasons: targetUserObject.reasons,
         preferences: {
           questionary: {
-            smoking: targetUserObject.preferences?.smoking[0] || "",
-            education: targetUserObject.preferences?.educationalLevel,
-            children: targetUserObject.preferences?.children[0] || "",
-            drinking: targetUserObject.preferences?.drinking[0] || "",
-            pets: targetUserObject.preferences?.pets,
-            language: targetUserObject.preferences?.selectedLanguages,
+            smoking: targetUserObject.preferences?.smoking || [],
+            education: targetUserObject.preferences?.educationalLevel || [],
+            children: targetUserObject.preferences?.children || [],
+            drinking: targetUserObject.preferences?.drinking || [],
+            pets: targetUserObject.preferences?.pets || [],
+            language: targetUserObject.preferences?.selectedLanguages || [],
           },
-          interests: targetUserObject.preferences?.interests,
-          aboutMe: targetUserObject.preferences?.aboutMe,
+          interests: targetUserObject.preferences?.interests || [],
+          aboutMe: targetUserObject.preferences?.aboutMe || "",
         },
       };
 


### PR DESCRIPTION
https://app.clickup.com/t/869cu11ge
## Summary                                                                                                           
  - getProfileById now returns full arrays for smoking, children, drinking, education, pets, language instead of first
  element only                                                                                                         
  - Age calculation standardized to moment().diff() across getProfileById and getMatches — was off by 1 year before  
  birthday                                                                                                             
                                                                                                                     
  ## Root cause                                                                                                        
  smoking[0], children[0], drinking[0] returned a string instead of array.                                           
  When the field was empty it returned "" causing fields to appear blank in Full Profile view.                         
  Frontend's printInterest() handles both string and array so this change is safe.                                     
                                                                                                                       
  ## Related bugs                                                                                                      
  - Optional profile fields not displayed in another user's Full Profile view                                          
  - Profile Card of a matched friend does not display profile information 