### PR TITLE
fix(869bbrwv8): remove matched friend from New Friends tab after chat is initiated

### DIFF
--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -12,3 +12,4 @@ if (!admin.apps.length) {
 }
 
 export const firebaseDb = admin.database()
+export const firestore = admin.firestore()

--- a/src/modules/chat/chat.controller.ts
+++ b/src/modules/chat/chat.controller.ts
@@ -42,11 +42,11 @@ export class ChatController {
       if (!hasMatch) {
         return res.status(400).send({ message: "You are not friends" });
       }
-      const existingChat = await this.chatService.getChatByParticipants(
+      const chatExists = await this.chatService.getChatByParticipants(
         userId,
         friendId
       );
-      if (existingChat) {
+      if (chatExists) {
         return res.status(400).send({ message: "Chat already exists" });
       }
 

--- a/src/modules/chat/chat.service.ts
+++ b/src/modules/chat/chat.service.ts
@@ -1,4 +1,5 @@
 import Chat, { IChat } from "./chat.model";
+import { firestore } from "../../config/firebase";
 
 export class ChatService {
   async getAllChats(): Promise<IChat[]> {
@@ -16,10 +17,17 @@ export class ChatService {
   async getChatByParticipants(
     userId: string,
     friendId: string
-  ): Promise<IChat | null> {
-    return await Chat.findOne({
-      participants: { $all: [userId, friendId] },
-    });
+  ): Promise<boolean> {
+    try {
+      const conversationId = [userId, friendId].sort().join("_");
+      const doc = await firestore
+        .collection("conversations")
+        .doc(conversationId)
+        .get();
+      return doc.exists;
+    } catch {
+      return false;
+    }
   }
 
   async getChatById(id: string): Promise<IChat | null> {


### PR DESCRIPTION
https://app.clickup.com/t/9012052932/869bbrwv8

###  Problem
Matched friends were not being removed from the "New Friends" tab after a chat was started. The backend was checking MongoDB's Chat collection to determine if a conversation existed, but the frontend uses Firebase Firestore exclusively for chats - so MongoDB Chat was never populated and the filter never triggered.
### Solution
Integrated Firebase Admin SDK into the backend. `getChatByParticipants` now queries Firestore using the same conversation ID format the frontend uses (`[userId, friendId].sort().join('_')`). If a conversation document exists in Firestore, the matched friend is filtered out from the `GET /matches` response.
### Changes
- Added `firebase-admin` dependency
- Added `src/config/firebase.ts` - Firebase Admin initialization via env vars
- Updated `ChatService.getChatByParticipants` to check Firestore instead of MongoDB
- Added error fallback: if Firestore is unavailable, returns `false` (friend stays visible) instead of crashing