### PR TITLE
refactor(869dge3u7): unify photos response format to string array across profile endpoints

### DIFF
--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -150,9 +150,7 @@ export class ProfileController {
           currentUserObject.location.coordinates[0]
         ),
         likedMe,
-        photos: targetUserObject.photos.map((photo: string) => ({
-          src: photo,
-        })),
+        photos: targetUserObject.photos || [],
         reasons: targetUserObject.reasons,
         preferences: {
           questionary: {

--- a/src/modules/profile/profile.route.ts
+++ b/src/modules/profile/profile.route.ts
@@ -206,10 +206,7 @@ router.get("/nearest", checkJwt, profileController.getNearestProfiles);
  *                   photos:
  *                     type: array
  *                     items:
- *                       type: object
- *                       properties:
- *                         src:
- *                           type: string
+ *                       type: string
  *                   reasons:
  *                     type: array
  *                     items:

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -407,7 +407,7 @@ export class ProfileService {
             likedMe,
             distance,
             city: friendObject.location?.city || "",
-            photos: friendObject.photos?.map((photo) => ({ src: photo })) || [],
+            photos: friendObject.photos || [],
             preferences: {
               questionary: {
                 smoking: friendObject.preferences?.smoking || [],


### PR DESCRIPTION
https://app.clickup.com/t/869dge3u7

### Problem
The `photos` field was returned in two different formats across profile endpoints:
- `GET /api/profile`, `GET /api/profile/all` → `photos: ["string"]` (array of strings)
- `GET /api/profile/{userId}`, `GET /api/profile/search` → `photos: [{ src: "string" }]` (array of objects)

This inconsistency forced the frontend to handle two shapes for the same field.

### Solution
Unified all endpoints to return `photos: ["string"]`, matching how photos are actually stored in the database (`string[]`).

### Changes
- `profile.controller.ts` - `getProfileById` (`/api/profile/{userId}`): removed the `.map(photo => ({ src: photo }))` transformation
- `profile.service.ts` - `searchFriends` (`/api/profile/search`): same change
- `profile.route.ts` - fixed the Swagger doc for `/api/profile/all` where photos were incorrectly documented as an array of `{ src }` objects

### Not changed
- `GET /api/profile/nearest` uses a single `picture` string field (not `photos`), so it is out of scope

### Note for frontend
This is a breaking change for any screen that reads `photo.src` - those should now read the string directly.