### PR TITLE
feat(869b866h9): sort likes-on-me by most recent and skip deleted pro…

### DIFF
--- a/src/modules/like/like.service.ts
+++ b/src/modules/like/like.service.ts
@@ -97,24 +97,40 @@ export class LikeService {
     try {
       const liker = await this.profileService.getProfileById(liker_id);
       const likedMe = await Like.find({ "likes.liked_id": liker_id }).exec();
-      const likedMeIds = likedMe.map((like) => like.liker_id);
+
       const likedMeUsers = await Promise.all(
-        likedMeIds.map((id) => {
-          return this.profileService.getProfileById(id);
+        likedMe.map(async (like) => {
+          const likedEntry = like.likes.find(
+            (entry) => entry.liked_id === liker_id
+          );
+          const user = await this.profileService
+            .getProfileById(like.liker_id)
+            .catch(() => null);
+          if (!user) {
+            return null;
+          }
+          return {
+            id: user._id,
+            name: user.name,
+            distance: haversineDistance(
+              user.location.coordinates[1],
+              user.location.coordinates[0],
+              liker.location.coordinates[1],
+              liker.location.coordinates[0]
+            ),
+            picture: user.photos?.[0] || null,
+            liked_at: likedEntry?.liked_at ?? null,
+          };
         })
       );
-      const likedMeResult = likedMeUsers.map((user) => ({
-        id: user._id,
-        name: user.name,
-        distance: haversineDistance(
-          user.location.coordinates[1],
-          user.location.coordinates[0],
-          liker.location.coordinates[1],
-          liker.location.coordinates[0]
-        ),
-        picture: user.photos?.[0] || null,
-      }));
-      return likedMeResult;
+
+      return likedMeUsers
+        .filter((user): user is NonNullable<typeof user> => user !== null)
+        .sort(
+          (a, b) =>
+            new Date(b.liked_at ?? 0).getTime() -
+            new Date(a.liked_at ?? 0).getTime()
+        );
     } catch (error: unknown) {
       if (error instanceof Error) {
         throw new Error(error.message);


### PR DESCRIPTION
https://app.clickup.com/t/869b866h9

###  Task
869b866h9 - Likes list sort by (add date of receiving a like, sort recent first)

###  Problem
- The "Your likes list" (`GET /api/likes/on-me`) returned likes in document order, oldest first, instead of recent first (Scenario 7).
- The list failed with 500 "Profile not found" when any liker's profile had been deleted, leaving the whole list empty for the user.

###  Solution
All changes are in `getLikesOnMe` (`like.service.ts`):
- Surface `liked_at` for each liker (the date the like was received) in the response.
- Sort the list by `liked_at` descending so recent likes appear first.
- Skip likers whose profile was deleted instead of failing the whole request, so one missing profile no longer empties the list.

###  Notes
- The `liked_at` field already exists in the likes collection (set on `addLike`), so no schema migration was needed.
- No changes to other endpoints.