### PR TITLE
fix(869d6m827): change firebase logic

### DIFF
--- a/src/modules/like/like.route.ts
+++ b/src/modules/like/like.route.ts
@@ -4,12 +4,13 @@ import { LikeController } from "./like.controller";
 import { LikeService } from "./like.service";
 import { ProfileService } from "../profile/profile.service";
 import { MatchService } from "../match/match.service";
+import { FirebaseMatchRepository } from "../match/match.repository";
 
 const router = Router();
 
 const profileService = new ProfileService();
 const matchService = new MatchService();
-const likeService = new LikeService(profileService, matchService);
+const likeService = new LikeService(profileService, matchService, new FirebaseMatchRepository());
 const likeController = new LikeController(likeService);
 
 /**

--- a/src/modules/like/like.service.ts
+++ b/src/modules/like/like.service.ts
@@ -3,15 +3,18 @@ import { Like } from "../../models";
 import { haversineDistance } from "../../utils";
 import { ProfileService } from "../profile/profile.service";
 import { MatchService } from "../match/match.service";
+import { IFirebaseRepository } from "../match/match.repository";
 
 
 export class LikeService {
   private profileService: ProfileService;
   private matchService: MatchService;
+  private firebaseRepository: IFirebaseRepository;
 
-  constructor(profileService: ProfileService, matchService: MatchService) {
+  constructor(profileService: ProfileService, matchService: MatchService, firebaseRepository: IFirebaseRepository) {
     this.profileService = profileService;
     this.matchService = matchService;
+    this.firebaseRepository = firebaseRepository;
   }
 
   addLike = async (liker_id: string, liked_id: string) => {
@@ -34,6 +37,7 @@ export class LikeService {
           { new: true, session}
         ).exec();
         await session.commitTransaction();
+        await this.firebaseRepository.create(liked_id, liker_id);
         
         return match;
       }

--- a/src/modules/match/match.controller.ts
+++ b/src/modules/match/match.controller.ts
@@ -91,15 +91,15 @@ export class MatchController {
         .json({ message: "Unauthorized: No token provided" });
     }
     try {
-      const { user2_id, seen } = req.body;
+      const { user2_id } = req.body;
 
-      if (!user2_id || typeof seen !== "boolean") {
+      if (!user2_id) {
         return res.status(400).json({
-          message: "user2_id and a boolean seen value are required",
+          message: "user2_id is required",
         });
       }
 
-      const result = await this.matchService.editMatch(userId, user2_id, seen);
+      const result = await this.matchService.editMatch(userId, user2_id);
       return res.status(200).json(result);
     } catch (error: unknown) {
       return handleServiceError(error, "Error editMatch", res, 404);

--- a/src/modules/match/match.repository.ts
+++ b/src/modules/match/match.repository.ts
@@ -75,14 +75,10 @@ export class MongoMatchRepository implements IMatchRepository {
 export class FirebaseMatchRepository implements IFirebaseRepository {
   async create(user1_id: string, user2_id: string): Promise<any> {
     const comboId = [user1_id, user2_id].sort().join("_");
-    
-    const matchData = { type: "match", createdAt: new Date().toISOString() };
-
     const updates: Record<string, any> = {};
 
-    updates[`/matches/${comboId}`] = { ...matchData, users: { [user1_id]: true, [user2_id]: true } };
-    updates[`/user_matches/${user1_id}/${comboId}`] = true;
-    updates[`/user_matches/${user2_id}/${comboId}`] = true;
+    updates[`/matches/${user1_id}/${comboId}`] = true;
+    updates[`/matches/${user2_id}/${comboId}`] = true;
 
     await firebaseDb.ref().update(updates);
     
@@ -94,9 +90,8 @@ export class FirebaseMatchRepository implements IFirebaseRepository {
 
     const updates: Record<string, any> = {};
 
-    updates[`/matches/${comboId}`] = null;
-    updates[`/user_matches/${user1_id}/${comboId}`] = null;
-    updates[`/user_matches/${user2_id}/${comboId}`] = null;
+    updates[`/matches/${user1_id}/${comboId}`] = null;
+    updates[`/matches/${user2_id}/${comboId}`] = null;
 
     await firebaseDb.ref().update(updates);
 

--- a/src/modules/match/match.route.ts
+++ b/src/modules/match/match.route.ts
@@ -107,13 +107,10 @@ router.delete("/", checkJwt, matchController.removeMatch);
  *             type: object
  *             required:
  *               - user2_id
- *               - seen
  *             properties:
  *               user2_id:
  *                 type: string
- *               seen:
- *                 type: boolean
- *                 description: Desired seen value for the authenticated user
+ *                 description: The Auth0 ID of the other user in the match to mark the interaction as seen
  *     responses:
  *       200:
  *         description: match updated successfully

--- a/src/modules/match/match.service.ts
+++ b/src/modules/match/match.service.ts
@@ -38,25 +38,25 @@ export class MatchService {
     }
   };
 
-  editMatch = async (user1_id: string, user2_id: string, seen: boolean) => {
+  editMatch = async (authUserId: string, user2_id: string) => {
     try {
-      const match = await this.mongoRepository.findMatch(user1_id, user2_id);
+      const match = await this.mongoRepository.findMatch(authUserId, user2_id);
       if (!match) {
         throw new Error("Match not found");
       }
 
       const update: { user1_seen?: boolean; user2_seen?: boolean } = {};
 
-      if (match.user1_id === user1_id) {
-        update.user1_seen = seen;
-      } else if (match.user2_id === user1_id) {
-        update.user2_seen = seen;
+      if (match.user1_id === authUserId) {
+        update.user1_seen = true;
+      } else if (match.user2_id === authUserId) {
+        update.user2_seen = true;
       } else {
         throw new Error("Unauthorized to edit match");
       }
 
       const targetMatch = await this.mongoRepository.editMatch(
-        user1_id,
+        authUserId,
         user2_id,
         update
       );

--- a/src/modules/match/match.service.ts
+++ b/src/modules/match/match.service.ts
@@ -75,9 +75,15 @@ export class MatchService {
       if (matches.length === 0) {
         return [];
       }
-      const friendsIds: string[] = matches.map((match) =>
-        match.user1_id === user_id ? match.user2_id : match.user1_id
-      );
+
+      const friendSeenMap: Record<string, boolean> = {};
+      matches.forEach((match) => {
+        const friendId = match.user1_id === user_id ? match.user2_id : match.user1_id;
+        const friendSeen = match.user1_id === user_id ? match.user1_seen : match.user2_seen;
+        friendSeenMap[friendId] = friendSeen;
+      })
+
+      const friendsIds = Object.keys(friendSeenMap);
 
       const friends = await Promise.all(
         friendsIds.map((friendId) =>
@@ -85,26 +91,23 @@ export class MatchService {
         )
       );
 
-      const friendsWithChats = await Promise.all(
-        friends.map(async (friend) => ({
-          friend,
-          hasChat: !!(await this.chatService.getChatByParticipants(
-            user_id,
-            friend.id
-          )),
-        }))
-      );
+      const modifiedFriends = await Promise.all(friends.map(async (friendDoc) => {
+        if (!friendDoc) return null;
 
-      const modifiedFriends = friendsWithChats
-        .filter(({ hasChat }) => !hasChat)
-        .map(({ friend }) => ({
-          id: friend.id,
-          name: friend.name,
-          age: moment().diff(moment(friend.dateOfBirth), "years"),
-          photo: friend.photos?.[0] || null,
-        }));
+        const friendObj = friendDoc.toObject({ virtuals: true });
+        const friendStrId = friendObj._id.toString();
+        const hasChat = !!(await this.chatService.getChatByParticipants(user_id, friendStrId));
+        if (hasChat) return null;
+        return {
+          id: friendStrId,
+          name: friendObj.name,
+          age: moment().diff(moment(friendObj.dateOfBirth), "years"),
+          photo: friendObj.photos?.[0] || null,
+          seen: friendSeenMap[friendStrId],
+        };
+      }));
 
-      return modifiedFriends;
+      return modifiedFriends.filter((friend): friend is NonNullable<typeof friend> => friend !== null);
     } catch (error: unknown) {
       if (error instanceof Error) {
         throw new Error(error.message);

--- a/src/modules/match/match.service.ts
+++ b/src/modules/match/match.service.ts
@@ -29,7 +29,6 @@ export class MatchService {
       }
 
       const newMatch = await this.mongoRepository.create(user1_id, user2_id, options);
-      await this.firebaseRepository.create(user1_id, user2_id);
 
       return newMatch;
     } catch (error: unknown) {

--- a/src/modules/profile/profile.route.ts
+++ b/src/modules/profile/profile.route.ts
@@ -4,10 +4,11 @@ import { ProfileController } from "./profile.controller";
 import { ProfileService } from "./profile.service";
 import { LikeService } from "../like/like.service";
 import { MatchService } from "../match/match.service";
+import { FirebaseMatchRepository } from "../match/match.repository";
 
 const router = Router();
 
-const likeService = new LikeService(new ProfileService(), new MatchService());
+const likeService = new LikeService(new ProfileService(), new MatchService(), new FirebaseMatchRepository());
 const profileService = new ProfileService(likeService);
 const matchService = new MatchService(undefined, profileService);
 profileService["matchService"] = matchService;


### PR DESCRIPTION
[Task](https://app.clickup.com/t/9012052932/869d6m827)

###  Problems:
- [x] Empty fields on frontend: When a match occurred, the frontend received empty fields. 
- [x] Feature request: Need a way to track whether a user has seen the match.

###  Solution:
-  Firebase match was triggered earlier than MongoDB updated. Because of this, fields on the frontend did not refresh. This happened because Firebase Realtime was updated during the MongoDB session, meaning the match was created in Firebase before the data was actually saved in MongoDB.

###  Changes:
- Moved the Firebase write operation to the addLike method (executed after the MongoDB session finishes) and added the required dependencies.
- Added the seen field for future match notification functionality.
- Cleaned up redundant test data in Firebase.

## Match Logic (the seen field):

1. Match is created: {... , seen: false}
1. User views the match on frontend $\rightarrow$ triggers PATCH /match body: {"user2_id": "123"}
1. Status changes to: {... , seen: true}
1. If the match is deleted (contact deleted) $\rightarrow$ the process can start over.

## Endpoints:
`PATCH /match` – Changes the seen field status from false to true. We only send the ID of the user who was viewed from our profile. (Note: Removed the ability to change the seen field back to false).
`GET /match` – Added the seen field to the response (false = match not viewed, true = viewed).