### PR TITLE
feat(869cu0wn7): mirror block behavior on report and hide users in bo…

### DIFF
--- a/src/modules/block/block.controller.ts
+++ b/src/modules/block/block.controller.ts
@@ -9,12 +9,8 @@ export class BlockController {
     this.blockService = blockService;
   }
 
-  /**
-   * POST /api/block
-   * Body: { blockedUserId: string }
-   * blockerUserId is taken from the JWT (extractUserId).
-   */
   blockUser = async (req: Request, res: Response): Promise<Response> => {
+    console.log("controller blockUser");
     const blockerUserId = extractUserId(req);
     if (!blockerUserId) {
       return res

--- a/src/modules/block/block.route.ts
+++ b/src/modules/block/block.route.ts
@@ -5,11 +5,6 @@ import { checkJwt } from "../../middleware";
 const router = Router();
 const blockController = new BlockController();
 
-/**
- * POST /api/block
- * Block a user: removes match, adds to blackList.
- * blockerUserId is taken from the JWT.
- */
 router.post("/", checkJwt, blockController.blockUser);
 
 export default router;

--- a/src/modules/block/block.service.ts
+++ b/src/modules/block/block.service.ts
@@ -2,40 +2,33 @@ import Block from "./block.model";
 import { Match, Profile } from "../../models";
 
 export class BlockService {
-  /**
-   * POST /api/block
-   * - Saves block record
-   * - Deletes the match between the two users (if any)
-   * - Adds blockedUserId to the blocker's blackList so the blocked user
-   *   is excluded from future search results
-   *
-   * NOTE: Chat deletion is intentionally omitted. Frontend handles chat
-   * creation; backend-generated chats are deprecated and no longer used.
-   * See refactoring task: https://app.clickup.com/t/869d8qe6a
-   */
+  applyBlockEffects = async (
+    initiatorUserId: string,
+    targetUserId: string
+  ): Promise<void> => {
+    await Match.deleteOne({
+      $or: [
+        { user1_id: initiatorUserId, user2_id: targetUserId },
+        { user1_id: targetUserId, user2_id: initiatorUserId },
+      ],
+    });
+
+    await Profile.findByIdAndUpdate(initiatorUserId, {
+      $addToSet: { blackList: targetUserId },
+    });
+  };
+
   blockUser = async (
     blockerUserId: string,
     blockedUserId: string
   ): Promise<{ message: string }> => {
     try {
-      // Save the block (ignore duplicate error — already blocked)
       const existing = await Block.findOne({ blockerUserId, blockedUserId });
       if (!existing) {
         await Block.create({ blockerUserId, blockedUserId });
       }
 
-      // Remove match (both directions)
-      await Match.deleteOne({
-        $or: [
-          { user1_id: blockerUserId, user2_id: blockedUserId },
-          { user1_id: blockedUserId, user2_id: blockerUserId },
-        ],
-      });
-
-      // Add to blackList of the blocker's profile so they never appear again
-      await Profile.findByIdAndUpdate(blockerUserId, {
-        $addToSet: { blackList: blockedUserId },
-      });
+      await this.applyBlockEffects(blockerUserId, blockedUserId);
 
       return { message: "User blocked successfully" };
     } catch (error: unknown) {
@@ -44,9 +37,6 @@ export class BlockService {
     }
   };
 
-  /**
-   * Returns the list of user IDs blocked by the given user.
-   */
   getBlockedUsers = async (blockerUserId: string): Promise<string[]> => {
     try {
       const blocks = await Block.find({ blockerUserId }).select("blockedUserId -_id");

--- a/src/modules/block/block.service.ts
+++ b/src/modules/block/block.service.ts
@@ -1,5 +1,5 @@
 import Block from "./block.model";
-import { Match, Profile } from "../../models";
+import { Match } from "../../models";
 
 export class BlockService {
   applyBlockEffects = async (
@@ -13,9 +13,16 @@ export class BlockService {
       ],
     });
 
-    await Profile.findByIdAndUpdate(initiatorUserId, {
-      $addToSet: { blackList: targetUserId },
-    });
+    await Block.updateOne(
+      { blockerUserId: initiatorUserId, blockedUserId: targetUserId },
+      {
+        $setOnInsert: {
+          blockerUserId: initiatorUserId,
+          blockedUserId: targetUserId,
+        },
+      },
+      { upsert: true }
+    );
   };
 
   blockUser = async (
@@ -23,13 +30,7 @@ export class BlockService {
     blockedUserId: string
   ): Promise<{ message: string }> => {
     try {
-      const existing = await Block.findOne({ blockerUserId, blockedUserId });
-      if (!existing) {
-        await Block.create({ blockerUserId, blockedUserId });
-      }
-
       await this.applyBlockEffects(blockerUserId, blockedUserId);
-
       return { message: "User blocked successfully" };
     } catch (error: unknown) {
       if (error instanceof Error) throw new Error(error.message);
@@ -37,10 +38,18 @@ export class BlockService {
     }
   };
 
-  getBlockedUsers = async (blockerUserId: string): Promise<string[]> => {
+  getBlockedUsers = async (userId: string): Promise<string[]> => {
+    console.log("controller getBlockedUsers");
     try {
-      const blocks = await Block.find({ blockerUserId }).select("blockedUserId -_id");
-      return blocks.map((b) => b.blockedUserId);
+      const blocks = await Block.find({
+        $or: [{ blockerUserId: userId }, { blockedUserId: userId }],
+      }).select("blockerUserId blockedUserId -_id");
+
+      const ids = blocks.map((b) =>
+        b.blockerUserId === userId ? b.blockedUserId : b.blockerUserId
+      );
+
+      return Array.from(new Set(ids));
     } catch (error: unknown) {
       if (error instanceof Error) throw new Error(error.message);
       throw new Error("Error fetching blocked users");

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -228,7 +228,6 @@ export class ProfileController {
         friendsDistance,
         friendsAgeMin,
         friendsAgeMax,
-        blackList,
       } = req.body;
 
       const friendsDistanceNum = friendsDistance
@@ -270,8 +269,7 @@ export class ProfileController {
         friendsDistanceNum,
         friendsAgeMinNum,
         friendsAgeMaxNum,
-        parsedPreferences,
-        blackList
+        parsedPreferences
       );
 
       return res.status(200).json(updatedProfile);

--- a/src/modules/profile/profile.model.ts
+++ b/src/modules/profile/profile.model.ts
@@ -35,7 +35,6 @@ export interface ProfileDocument extends Document {
   friendsAgeMin?: number;
   friendsAgeMax?: number;
   friendsDistance?: number;
-  blackList?: string[];
   reportCount: number;
 }
 
@@ -71,7 +70,6 @@ const profileSchema = new Schema<ProfileDocument>(
     friendsAgeMin: { type: Number, default: 18 },
     friendsAgeMax: { type: Number, default: 60 },
     friendsDistance: { type: Number, default: 50 },
-    blackList: { type: [String], default: [] },
     reportCount: { type: Number, default: 0 },
   },
   { timestamps: true }

--- a/src/modules/profile/profile.route.ts
+++ b/src/modules/profile/profile.route.ts
@@ -315,10 +315,6 @@ router.get("/:userId", checkJwt, profileController.getProfileById);
  *                 type: array
  *                 items:
  *                   type: string
- *               blackList:
- *                 type: array
- *                 items:
- *                   type: string
  *               friendsAgeMin:
  *                 type: number
  *               friendsAgeMax:

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -320,9 +320,14 @@ export class ProfileService {
       const friendsAgeMax = profile.friendsAgeMax;
       const blackList = profile.blackList || [];
 
-      // Exclude users that this user has explicitly blocked via /api/block
       const blockedUserIds = await this.blockService.getBlockedUsers(userId);
-      const excludedIds = Array.from(new Set([...blackList, ...blockedUserIds]));
+      const hiddenByOthers = await Profile.find({ blackList: userId })
+        .select("_id")
+        .lean<{ _id: string }[]>();
+      const hiddenByOthersIds = hiddenByOthers.map((p) => p._id);
+      const excludedIds = Array.from(
+        new Set([...blackList, ...blockedUserIds, ...hiddenByOthersIds])
+      );
 
       if (
         lng === undefined ||

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -197,8 +197,7 @@ export class ProfileService {
     friendsDistance?: number,
     friendsAgeMin?: number,
     friendsAgeMax?: number,
-    preferences?: Preferences,
-    blackList?: string[] | string
+    preferences?: Preferences
   ): Promise<ProfileDocument> => {
     try {
       const existingProfile = await Profile.findById(userId).exec();
@@ -210,9 +209,6 @@ export class ProfileService {
         typeof reasons === "string" ? JSON.parse(reasons) : reasons;
 
       const parsedLocation: Location = toGeoJsonLocation(location);
-
-      const parsedBlackList: string[] =
-        typeof blackList === "string" ? JSON.parse(blackList) : blackList;
 
       const updateData: Partial<ProfileDocument> = {
         reasons: parsedReasons,
@@ -255,10 +251,6 @@ export class ProfileService {
 
       if (friendsAgeMax !== undefined) {
         updateData.friendsAgeMax = friendsAgeMax;
-      }
-
-      if (parsedBlackList && parsedBlackList.length > 0) {
-        updateData.blackList = parsedBlackList;
       }
 
       const updatedProfile = await Profile.findByIdAndUpdate(
@@ -318,16 +310,8 @@ export class ProfileService {
       const friendsDistance = profile.friendsDistance;
       const friendsAgeMin = profile.friendsAgeMin;
       const friendsAgeMax = profile.friendsAgeMax;
-      const blackList = profile.blackList || [];
 
-      const blockedUserIds = await this.blockService.getBlockedUsers(userId);
-      const hiddenByOthers = await Profile.find({ blackList: userId })
-        .select("_id")
-        .lean<{ _id: string }[]>();
-      const hiddenByOthersIds = hiddenByOthers.map((p) => p._id);
-      const excludedIds = Array.from(
-        new Set([...blackList, ...blockedUserIds, ...hiddenByOthersIds])
-      );
+      const excludedIds = await this.blockService.getBlockedUsers(userId);
 
       if (
         lng === undefined ||

--- a/src/modules/report/report.service.ts
+++ b/src/modules/report/report.service.ts
@@ -1,5 +1,6 @@
 import Report, { ReportReason } from "./report.model";
 import { Profile } from "../../models";
+import { BlockService } from "../block/block.service";
 import {
   sendReportThresholdAlert,
   sendWeeklyReportDigest,
@@ -9,11 +10,12 @@ import {
 const REPORT_THRESHOLD = 5;
 
 export class ReportService {
-  /**
-   * POST /api/report
-   * Saves a complaint, increments the reported user's counter,
-   * and fires an alert email when the threshold is reached.
-   */
+  private blockService: BlockService;
+
+  constructor(blockService: BlockService = new BlockService()) {
+    this.blockService = blockService;
+  }
+
   createReport = async (
     reportedUserId: string,
     reporterUserId: string,
@@ -21,10 +23,10 @@ export class ReportService {
     comment?: string
   ): Promise<{ message: string; reportCount: number }> => {
     try {
-      // Persist the report
       await Report.create({ reportedUserId, reporterUserId, reason, comment });
 
-      // Atomically increment the counter and get the new value
+      await this.blockService.applyBlockEffects(reporterUserId, reportedUserId);
+
       const updatedProfile = await Profile.findByIdAndUpdate(
         reportedUserId,
         { $inc: { reportCount: 1 } },
@@ -33,7 +35,6 @@ export class ReportService {
 
       const reportCount = updatedProfile?.reportCount ?? 0;
 
-      // Send alert email exactly when the threshold is first crossed
       if (reportCount >= REPORT_THRESHOLD && reportCount % REPORT_THRESHOLD === 0) {
         sendReportThresholdAlert(reportedUserId, reportCount).catch((err) =>
           console.error("Failed to send threshold alert email:", err)
@@ -47,10 +48,6 @@ export class ReportService {
     }
   };
 
-  /**
-   * Collects all reports from the past 7 days and emails a digest to the admin.
-   * Called by the weekly cron job.
-   */
   sendWeeklyDigest = async (): Promise<void> => {
     try {
       const since = new Date();


### PR DESCRIPTION
https://app.clickup.com/t/869cu0wn7


## What was done
Report now mirrors block behavior, and block/report hide users in both directions.

## Changes
- `block.service.ts`: extracted block side effects (delete match, add target to blocker blackList) into a shared `applyBlockEffects` method.
- `report.service.ts`: `createReport` now calls `applyBlockEffects`, so a report deletes the match and hides users just like block does.
- `profile.service.ts`: search now also excludes users who have the current user in their blackList, so block and report hide both users from each other.