### PR TITLE
fix(cors): allow PATCH method for profile update preflight

### DIFF
--- a/src/config/middleware.ts
+++ b/src/config/middleware.ts
@@ -9,7 +9,7 @@ export const setupMiddleware = (app: Express): void => {
     cors({
       origin: ["http://localhost:3000", 'https://frontend.wefriiends.com', 'https://warm-frangollo-93bfd5.netlify.app'], // Replace with your frontend's URL
       allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"],
-      methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+      methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
       maxAge: 600,
     })
   );


### PR DESCRIPTION
The PATCH /api/profile route existed but CORS did not list PATCH in Access-Control-Allow-Methods, so the browser blocked the preflight for profile editing from the frontend. Added PATCH to the allowed methods.