### PR TITLE
fix(profile): make location optional on profile PATCH

### DIFF
--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -192,7 +192,7 @@ export class ProfileService {
   updateProfile = async (
     userId: string,
     reasons: string[],
-    location: Location | string,
+    location?: Location | string,
     photos?: string[],
     friendsDistance?: number,
     friendsAgeMin?: number,
@@ -209,15 +209,16 @@ export class ProfileService {
       const parsedReasons: string[] =
         typeof reasons === "string" ? JSON.parse(reasons) : reasons;
 
-      const parsedLocation: Location = toGeoJsonLocation(location);
-
       const parsedBlackList: string[] =
         typeof blackList === "string" ? JSON.parse(blackList) : blackList;
 
       const updateData: Partial<ProfileDocument> = {
         reasons: parsedReasons,
-        location: parsedLocation,
       };
+
+      if (location !== undefined && location !== null) {
+        updateData.location = toGeoJsonLocation(location);
+      }
 
       if (photos && photos.length > 0) {
         updateData.photos = photos;


### PR DESCRIPTION
What was done.
Fixed PATCH /api/profile failing on partial updates that do not include location.

Problem.
The update handler always converted location to GeoJSON, so a partial body like preferences and reasons without location crashed with, cannot read properties of undefined reading coordinates, and the server returned 400.

Changes.
In updateProfile the location is now converted and updated only when it is present in the body. If location is absent the existing location stays untouched. If location is present it is converted from lat lng to coordinates and updated as before.