### PR TITLE
fix(profile): remove orphaned blackList reference in updateProfile

### DIFF
--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -208,9 +208,6 @@ export class ProfileService {
       const parsedReasons: string[] =
         typeof reasons === "string" ? JSON.parse(reasons) : reasons;
 
-      const parsedBlackList: string[] =
-        typeof blackList === "string" ? JSON.parse(blackList) : blackList;
-
       const updateData: Partial<ProfileDocument> = {
         reasons: parsedReasons,
       };


### PR DESCRIPTION
What was done.
Fixed the broken TypeScript build on main after the location and blackList changes were merged together.

Problem.
updateProfile kept a leftover line, const parsedBlackList referencing an undeclared blackList, which failed compilation with TS2304. The variable was not used anywhere in updateData.

Changes.
Removed the dead parsedBlackList line. Build passes now, npm run build is clean.