### PR TITLE
refactor(match): migrate live match from Realtime Database to Firestore

### DIFF
--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -11,5 +11,4 @@ if (!admin.apps.length) {
   })
 }
 
-export const firebaseDb = admin.database()
 export const firestore = admin.firestore()

--- a/src/modules/like/like.route.ts
+++ b/src/modules/like/like.route.ts
@@ -4,13 +4,13 @@ import { LikeController } from "./like.controller";
 import { LikeService } from "./like.service";
 import { ProfileService } from "../profile/profile.service";
 import { MatchService } from "../match/match.service";
-import { FirebaseMatchRepository } from "../match/match.repository";
+import { LiveMatchRepository } from "../match/match.repository";
 
 const router = Router();
 
 const profileService = new ProfileService();
 const matchService = new MatchService();
-const likeService = new LikeService(profileService, matchService, new FirebaseMatchRepository());
+const likeService = new LikeService(profileService, matchService, new LiveMatchRepository());
 const likeController = new LikeController(likeService);
 
 /**

--- a/src/modules/like/like.service.ts
+++ b/src/modules/like/like.service.ts
@@ -3,18 +3,18 @@ import { Like } from "../../models";
 import { haversineDistance } from "../../utils";
 import { ProfileService } from "../profile/profile.service";
 import { MatchService } from "../match/match.service";
-import { IFirebaseRepository } from "../match/match.repository";
+import { ILiveMatchRepository } from "../match/match.repository";
 
 
 export class LikeService {
   private profileService: ProfileService;
   private matchService: MatchService;
-  private firebaseRepository: IFirebaseRepository;
+  private liveMatchRepository: ILiveMatchRepository;
 
-  constructor(profileService: ProfileService, matchService: MatchService, firebaseRepository: IFirebaseRepository) {
+  constructor(profileService: ProfileService, matchService: MatchService, liveMatchRepository: ILiveMatchRepository) {
     this.profileService = profileService;
     this.matchService = matchService;
-    this.firebaseRepository = firebaseRepository;
+    this.liveMatchRepository = liveMatchRepository;
   }
 
   addLike = async (liker_id: string, liked_id: string) => {
@@ -37,7 +37,7 @@ export class LikeService {
           { new: true, session}
         ).exec();
         await session.commitTransaction();
-        await this.firebaseRepository.create(liked_id, liker_id);
+        await this.liveMatchRepository.create(liked_id, liker_id);
         
         return match;
       }

--- a/src/modules/match/match.repository.ts
+++ b/src/modules/match/match.repository.ts
@@ -1,6 +1,6 @@
 import { Match } from "../../models";
-import { firebaseDb } from "../../config/firebase";
 import { ClientSession } from "mongoose";
+import { firestore } from "../../config/firebase";
 
 export interface IMatchRepository {
   create(user1_id: string, user2_id: string, options?: MatchOptions): Promise<any>;
@@ -13,7 +13,7 @@ export interface IMatchRepository {
     update: Partial<{ user1_seen: boolean; user2_seen: boolean }>
   ): Promise<any | null>;
 }
-export interface IFirebaseRepository {
+export interface ILiveMatchRepository {
   create(user1_id: string, user2_id: string): Promise<any>;
   deleteMatch(user1_id: string, user2_id: string): Promise<any>;
 }
@@ -72,28 +72,25 @@ export class MongoMatchRepository implements IMatchRepository {
   }
 }
 
-export class FirebaseMatchRepository implements IFirebaseRepository {
+export class LiveMatchRepository implements ILiveMatchRepository {
   async create(user1_id: string, user2_id: string): Promise<any> {
     const comboId = [user1_id, user2_id].sort().join("_");
-    const updates: Record<string, any> = {};
+    const matchRef = firestore.collection('matches').doc(comboId);
 
-    updates[`/matches/${user1_id}/${comboId}`] = true;
-    updates[`/matches/${user2_id}/${comboId}`] = true;
+    await matchRef.set(
+      {
+        users: [user1_id, user2_id],
+      },
+      { merge: true }
+    );
 
-    await firebaseDb.ref().update(updates);
-    
     return { user1_id, user2_id, comboId };
   }
 
   async deleteMatch(user1_id: string, user2_id: string): Promise<any> {
     const comboId = [user1_id, user2_id].sort().join("_");
 
-    const updates: Record<string, any> = {};
-
-    updates[`/matches/${user1_id}/${comboId}`] = null;
-    updates[`/matches/${user2_id}/${comboId}`] = null;
-
-    await firebaseDb.ref().update(updates);
+    await firestore.collection('matches').doc(comboId).delete();
 
     return { success: true, comboId };
   }

--- a/src/modules/match/match.service.ts
+++ b/src/modules/match/match.service.ts
@@ -1,24 +1,24 @@
 import moment from "moment";
 import { ChatService } from "../chat/chat.service";
 import { ProfileService } from "../profile/profile.service";
-import { IMatchRepository, MongoMatchRepository, MatchOptions, IFirebaseRepository, FirebaseMatchRepository } from "./match.repository";
+import { IMatchRepository, MongoMatchRepository, MatchOptions, ILiveMatchRepository, LiveMatchRepository } from "./match.repository";
 
 export class MatchService {
   private mongoRepository: IMatchRepository;
   private profileService: ProfileService;
   private chatService: ChatService;
-  private firebaseRepository: IFirebaseRepository;
+  private liveMatchRepository: ILiveMatchRepository;
 
   constructor(
     mongoRepository: IMatchRepository = new MongoMatchRepository(),
     profileService: ProfileService = new ProfileService(),
     chatService: ChatService = new ChatService(),
-    firebaseRepository: IFirebaseRepository = new FirebaseMatchRepository(),
+    liveMatchRepository: ILiveMatchRepository = new LiveMatchRepository(),
   ) {
     this.mongoRepository = mongoRepository;
     this.profileService = profileService;
     this.chatService = chatService;
-    this.firebaseRepository = firebaseRepository;
+    this.liveMatchRepository = liveMatchRepository;
   }
 
   addMatch = async (user1_id: string, user2_id: string, options?: MatchOptions) => {
@@ -127,7 +127,7 @@ export class MatchService {
         user1_id,
         user2_id
       );
-      await this.firebaseRepository.deleteMatch(user1_id, user2_id);
+      await this.liveMatchRepository.deleteMatch(user1_id, user2_id);
 
       return mongoResult;
     } catch (error: unknown) {

--- a/src/modules/profile/profile.route.ts
+++ b/src/modules/profile/profile.route.ts
@@ -4,11 +4,11 @@ import { ProfileController } from "./profile.controller";
 import { ProfileService } from "./profile.service";
 import { LikeService } from "../like/like.service";
 import { MatchService } from "../match/match.service";
-import { FirebaseMatchRepository } from "../match/match.repository";
+import { LiveMatchRepository } from "../match/match.repository";
 
 const router = Router();
 
-const likeService = new LikeService(new ProfileService(), new MatchService(), new FirebaseMatchRepository());
+const likeService = new LikeService(new ProfileService(), new MatchService(), new LiveMatchRepository());
 const profileService = new ProfileService(likeService);
 const matchService = new MatchService(undefined, profileService);
 profileService["matchService"] = matchService;


### PR DESCRIPTION
[Task link](https://app.clickup.com/t/9012052932/869d6m827)
### Summary:
Migrated the live match storage and synchronization from Firebase Realtime Database to Firestore. 

**Why:**
- To unify our infrastructure and avoid maintaining multiple database types (RTDB + Firestore).
- To simplify profile deletion logic: since user chats and other related data already reside in Firestore, having matches in Firestore as well allows us to perform clean, unified batch/cascade deletions upon account removal.
### Changes:
**Config**: Removed Realtime Database (`firebaseDb`) initialization, leaving only `firestore` export.
- **Match Repository**:
  - Renamed `FirebaseMatchRepository` to `LiveMatchRepository`.
  - Renamed `IFirebaseRepository` interface to `ILiveMatchRepository`.
  - Updated match creation and deletion logic to use Firestore `matches` collection with deterministic `comboId` (`user1_id_user2_id`).
- **Services & Routes**: Updated dependency injection across `like`, `match`, and `profile` modules.

