### PR TITLE
feat(profile,like): filter blocked users from nearest and likes-on-me

### DIFF
--- a/src/modules/like/like.service.ts
+++ b/src/modules/like/like.service.ts
@@ -3,6 +3,7 @@ import { Like } from "../../models";
 import { haversineDistance } from "../../utils";
 import { ProfileService } from "../profile/profile.service";
 import { MatchService } from "../match/match.service";
+import { BlockService } from "../block/block.service";
 import { ILiveMatchRepository } from "../match/match.repository";
 
 
@@ -10,11 +11,13 @@ export class LikeService {
   private profileService: ProfileService;
   private matchService: MatchService;
   private liveMatchRepository: ILiveMatchRepository;
+  private blockService: BlockService;
 
-  constructor(profileService: ProfileService, matchService: MatchService, liveMatchRepository: ILiveMatchRepository) {
+  constructor(profileService: ProfileService, matchService: MatchService, liveMatchRepository: ILiveMatchRepository, blockService: BlockService = new BlockService()) {
     this.profileService = profileService;
     this.matchService = matchService;
     this.liveMatchRepository = liveMatchRepository;
+    this.blockService = blockService;
   }
 
   addLike = async (liker_id: string, liked_id: string) => {
@@ -101,9 +104,13 @@ export class LikeService {
     try {
       const liker = await this.profileService.getProfileById(liker_id);
       const likedMe = await Like.find({ "likes.liked_id": liker_id }).exec();
+      const blockedIds = new Set(await this.blockService.getBlockedUsers(liker_id));
 
       const likedMeUsers = await Promise.all(
         likedMe.map(async (like) => {
+          if (blockedIds.has(like.liker_id)) {
+            return null;
+          }
           const likedEntry = like.likes.find(
             (entry) => entry.liked_id === liker_id
           );

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -438,6 +438,7 @@ export class ProfileService {
       const allProfiles = await this.getAllProfiles(userId);
 
       const userLikes = this.likeService ? await this.likeService.getLikes(userId) : null;
+      const blockedIds = new Set(await this.blockService.getBlockedUsers(userId));
 
       const nearestProfiles = await Promise.all(
         allProfiles
@@ -455,6 +456,7 @@ export class ProfileService {
             );
 
             if (distance <= currentProfile.friendsDistance!) {
+              if (blockedIds.has(profile.id)) return null;
               const hasLiked = userLikes?.likes?.some((like) => like.liked_id === profile.id);
               const hasMatch = await this.matchService?.hasMatch(userId, profile.id);
               if (hasLiked || hasMatch) return null;


### PR DESCRIPTION
What was done.
Blocked users no longer appear on GET /api/profile/nearest and GET /api/likes/on-me.

Problem.
After blocking a user, they still came back in nearest profiles and likes-on-me, so they kept showing in the potential friends carousel.

Changes.
- profile.service.ts, getNearestProfiles now excludes users from blockService.getBlockedUsers.
- like.service.ts, getLikesOnMe now excludes them too, BlockService is injected via the constructor.
- Same approach as searchFriends. getBlockedUsers returns both directions, so mutual blocks are hidden.